### PR TITLE
Bug corrections in unregistered users vote and permissions

### DIFF
--- a/lib/AdvancedPolls/Api/User.php
+++ b/lib/AdvancedPolls/Api/User.php
@@ -543,7 +543,10 @@ class AdvancedPolls_Api_User extends Zikula_AbstractApi {
         // Security check
         if (SecurityUtil::checkPermission('AdvancedPolls::item',"{$args['title']}::{$args['pollid']}",ACCESS_COMMENT)) {
             $args['ip'] = $_SERVER['REMOTE_ADDR'];
-            $args['uid'] = UserUtil::getVar('uid');            
+            $args['uid'] = UserUtil::getVar('uid');
+            if (!$args['uid']) {
+                $args['uid'] = 0;
+            }
             
             $poll = new AdvancedPolls_Entity_Votes();
             $poll->setAll($args);

--- a/lib/AdvancedPolls/Controller/User.php
+++ b/lib/AdvancedPolls/Controller/User.php
@@ -387,7 +387,11 @@ class AdvancedPolls_Controller_User extends Zikula_AbstractController {
                         }
                     }
                 }
+            } else {
+                return LogUtil::registerPermissionError();
             }
+        } else {
+            return LogUtil::registerPermissionError();
         }
 
         LogUtil::registerStatus( $this->__('Done! Vote added.'));

--- a/templates/admin/modify.tpl
+++ b/templates/admin/modify.tpl
@@ -18,13 +18,13 @@
         <legend>{gt text="Basic Information"}</legend>
         <div class="z-formrow">
             {formlabel for="title"  __text='Name of poll'}
-            {formtextinput size="50" maxLength="100" id="title" mandatory=true"}
+            {formtextinput size="50" maxLength="255" id="title" mandatory=true"}
         </div>
 
                 
         <div class="z-formrow">
             {formlabel for="urltitle"  __text='PermaLink URL title'}
-            {formtextinput size="50" maxLength="120" id="urltitle"}
+            {formtextinput size="50" maxLength="255" id="urltitle"}
             <em class="z-formnote z-sub">{gt text="(Blank = auto-generate)"}</em>
         </div>
         
@@ -49,7 +49,7 @@
                 
         <div class="z-formrow">
             {formlabel for="description"  __text='Description'}
-            {formtextinput textMode="multiline" size="50" maxLength="100" id="description" rows="10" cols="50"}
+            {formtextinput textMode="multiline" size="50" maxLength="0" id="description" rows="10" cols="50"}
         </div>
         
         <div class="z-formrow">

--- a/templates/block/poll.tpl
+++ b/templates/block/poll.tpl
@@ -1,5 +1,5 @@
 <div id="advancedpollblockcontent">
-    <h2>{$item.title|safetext}</h2>
+    <h3>{$item.title|safetext}</h3>
     <p>{$item.description|safehtml}</p>
 
     {if $ispollopen and $isvoteallowed}
@@ -10,7 +10,7 @@
 
     <form id="advancedpollsvoteform" class="z-form" action="{modurl modname="advancedpolls" type="user" func="vote"}" method="post" enctype="application/x-www-form-urlencoded">
         <div>
-            <input type="hidden" name="authid" value="{insert name=csrftoken module="advancedpolls"}" />
+            <input type="hidden" name="authid" value="{insert name=csrftoken module='advancedpolls'}" />
             <input type="hidden" name="pollid" value="{$pollid|safetext}" />
             <input type="hidden" name="title" value="{$item.title|safehtml}" />
             <input type="hidden" name="results" value="1" />
@@ -36,9 +36,9 @@
             </fieldset>
             <div class="z-formbuttons">
                 {if $blockvars.ajaxvoting}
-                <input onclick="javascript:advancedpolls_vote();" name="vote" type="button" value="{gt text="Vote" domain="module_advancedpolls"}" />
+                <input onclick="javascript:advancedpolls_vote();" name="vote" type="button" value="{gt text='Vote' domain='module_advancedpolls'}" />
                 {else}
-                <input name="submit" type="submit" value="{gt text="Vote" domain="module_advancedpolls"}" />
+                <input name="submit" type="submit" value="{gt text='Vote' domain='module_advancedpolls'}" />
                 {/if}
             </div>
         </div>
@@ -72,6 +72,6 @@
         {/if}
         {/if}
         <li>{gt text="Total number of votes: %s" tag1=$votecounts.totalvotecount|default:0 domain="module_advancedpolls"}</li>
-        <li><a href="{modurl modname="advancedpolls" type="user" func="display" pollid=$pollid}">{gt text="Detailed results" domain="module_advancedpolls"}</a></li>
+        <li><a href="{modurl modname='advancedpolls' type='user' func='display' pollid=$pollid}">{gt text="Detailed results" domain="module_advancedpolls"}</a></li>
     </ul>
 </div>

--- a/templates/user/results.tpl
+++ b/templates/user/results.tpl
@@ -1,3 +1,4 @@
+{setmetatag name='description' value=$item.description|strip_tags|trim|truncate:255}
 {if $ispollopen eq 1}
     {gt text="Current poll: %s" tag1=$item.title|safetext assign=templatetitle}
 {else}

--- a/templates/user/results_short.tpl
+++ b/templates/user/results_short.tpl
@@ -1,3 +1,4 @@
+{setmetatag name='description' value=$item.description|strip_tags|trim|truncate:255}
 {if $ispollopen eq 1}
     {gt text="Current poll: %s" tag1=$item.title|safetext assign=templatetitle}
 {else}

--- a/templates/user/votingform.tpl
+++ b/templates/user/votingform.tpl
@@ -1,3 +1,4 @@
+{setmetatag name='description' value=$item.description|strip_tags|trim|truncate:255}
 {gt text="Voting booth: %s" tag1=$item.title|safetext assign=templatetitle}
 {include file="user/menu.tpl"}
 
@@ -9,7 +10,7 @@
 
 <form class="z-form" id="advanced_polls_admin_modify" action="{modurl modname='advancedpolls' type='user' func='vote'}" method="post" enctype="application/x-www-form-urlencoded">
     <div>
-        <input type="hidden" name="authid" value="{insert name=csrftoken module="advancedpolls"}" />
+        <input type="hidden" name="authid" value="{insert name=csrftoken module='advancedpolls'}" />
         <input type="hidden" name="pollid" value="{$pollid|safetext}" />
         <input type="hidden" name="title" value="{$item.title|safehtml}" />
         <input type="hidden" name="results" value="1" />
@@ -33,7 +34,7 @@
             {/if}
         </fieldset>
         <div class="z-formbuttons">
-            <input name="submit" type="submit" value="{gt text="Vote"}" />
+            <input name="submit" type="submit" value="{gt text='Vote'}" />
         </div>
     </div>
 </form>

--- a/templates/user/votingform_short.tpl
+++ b/templates/user/votingform_short.tpl
@@ -1,3 +1,4 @@
+{setmetatag name='description' value=$item.description|strip_tags|trim|truncate:255}
 {gt text="Voting booth: %s" tag1=$item.title|safetext assign=templatetitle}
 <h3>{$templatetitle}</h3>
 <p>{$item.description|safehtml}</p>


### PR DESCRIPTION
Descriptions for proposed changes are in the separate commits in this PR.
The main bug is error in flushing to votes table, in case the user is not registered. In this case ```$args['uid']``` remains empty, but must be integer zero for flushing without error.

I can say ```UserUtil::getVar('uid')``` is better to return zero instead of empty string, but this is in the core.